### PR TITLE
Added utils perf file generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 package-lock.json
 .idea/
 
+test/test_data/generated
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "rawTest": "babel-tape-runner test/code/*.cjs",
     "oneTest": "babel-tape-runner test/code/%TESTSCRIPT%.cjs",
     "build": "babel src -d dist",
-    "prepublishOnly": "rm -fr dist && npm run build"
+    "prepublishOnly": "rm -fr dist && npm run build",
+    "generatePerf": "babel-tape-runner utils/generatePerf.js",
+    "generatePerfHtml": "babel-tape-runner utils/generatePerfHtml.js"
   },
   "repository": {
     "type": "git",
@@ -35,6 +37,7 @@
     "babel-tape-runner": "^3.0.0",
     "eslint": "^8.15.0",
     "fs-extra": "^10.1.0",
+    "js-beautify": "^1.14.4",
     "path": "^0.12.7",
     "tap-summary": "^4.0.0",
     "tape": "^5.5.3",

--- a/utils/generatePerf.js
+++ b/utils/generatePerf.js
@@ -1,0 +1,37 @@
+const path = require("path");
+const fse = require("fs-extra");
+const {UWProskomma} = require("uw-proskomma");
+const EpiteletePerfHtml = require("../src/index").default;
+
+const args = process.argv.slice(3)
+const pk = new UWProskomma();
+
+console.log("Loading source to proskomma...");
+const succinctJson = fse.readJsonSync(path.resolve(path.join(__dirname, "..", "test", "test_data", "fra_lsg_succinct.json")));
+const docSetId = "eBible/fra_fraLSG";
+// const succinctJson = fse.readJsonSync(path.resolve(path.join(__dirname, "..", "test", "test_data", "eng_engWEBBE_succinct.json")));
+// const docSetId = "DBL/eng_engWEBBE";
+pk.loadSuccinctDocSet(succinctJson);
+
+export const generatePerf = async () => {
+  const instance = new EpiteletePerfHtml({proskomma: pk, docSetId});
+  const bookCode = (args?.[0] || "psa").toUpperCase();
+  if (! args[0]) 
+    console.log("\u001B[33m", `No book code provided, generating perf for ${bookCode} instead...`, "\u001B[0m")
+   else 
+    console.log(`Loading ${bookCode} document...`);
+  
+  const perf = await instance.readPerf(bookCode);
+  console.log("Generating json file...");
+  const dir = path.resolve(__dirname, "..", "test", "test_data", "generated");
+  if (! fse.pathExistsSync(dir)) 
+    fse.mkdirSync(dir);
+  
+  const safeDocSetId = instance.docSetId.replace("/", "-");
+  const fileName = `${bookCode}-${safeDocSetId}-perf_v${perf.schema.structure_version}.json`;
+  const filePath = path.resolve(dir, fileName);
+  fse.writeJsonSync(filePath, perf, {spaces: 2});
+  console.log("\u001B[32m", `✔ JSON file generated for ${bookCode} at ${filePath}`, "\u001B[0m");
+};
+
+if (process?.argv?.length) generatePerf();

--- a/utils/generatePerfHtml.js
+++ b/utils/generatePerfHtml.js
@@ -1,0 +1,38 @@
+const path = require("path");
+const fse = require("fs-extra");
+const {UWProskomma} = require("uw-proskomma");
+const EpiteletePerfHtml = require("../src/index").default;
+const beautify = require('js-beautify').html;
+
+const args = process?.argv?.slice(3)
+const pk = new UWProskomma();
+
+console.log("Loading source to proskomma...");
+const succinctJson = fse.readJsonSync(path.resolve(path.join(__dirname, "..", "test", "test_data", "fra_lsg_succinct.json")));
+const docSetId = "eBible/fra_fraLSG";
+// const succinctJson = fse.readJsonSync(path.resolve(path.join(__dirname, "..", "test", "test_data", "eng_engWEBBE_succinct.json")));
+// const docSetId = "DBL/eng_engWEBBE";
+pk.loadSuccinctDocSet(succinctJson);
+
+export const generatePerfHtml = async () => {
+  const instance = new EpiteletePerfHtml({proskomma: pk, docSetId});
+  const bookCode = (args[0] || "psa").toUpperCase();
+  if (! args[0]) 
+    console.log("\u001B[33m", `No book code provided, generating perfHtml for ${bookCode} instead...`, "\u001B[0m")
+   else 
+    console.log(`Generating perfHtml file...`);
+  
+  const perfHtml = await instance.readHtml(bookCode);
+  const sequenceId = args[1] || perfHtml.mainSequenceId;
+  const dir = path.resolve(__dirname, "..", "test", "test_data", "generated");
+  if (! fse.pathExistsSync(dir)) 
+    fse.mkdirSync(dir);
+  
+  const safeDocSetId = instance.docSetId.replace("/", "-");
+  const fileName = `${bookCode}-${safeDocSetId}-perf_v${perfHtml.schema.structure_version}.html`;
+  const filePath = path.resolve(dir, fileName);
+  fse.writeFileSync(filePath, beautify(perfHtml.sequencesHtml[sequenceId]), {encoding: 'utf8'});
+  console.log("\u001B[32m", `✔ HTML file generated for ${bookCode} at ${filePath}`, "\u001B[0m");
+};
+
+if (process?.argv?.length) generatePerfHtml();


### PR DESCRIPTION
This adds two new files (generatePerf.js and generatePerfHtml.js) that can be executed with their associated scripts in package.json (`generatePerf {bookcode}` and `generatePerfHtml {bookcode}`). I've used this to generate PERF files that I can then use for testing.